### PR TITLE
Flush stream after writing ZFP header

### DIFF
--- a/H5Zzfp.c
+++ b/H5Zzfp.c
@@ -346,6 +346,9 @@ H5Z_zfp_set_local(hid_t dcpl_id, hid_t type_id, hid_t chunk_space_id)
     if (0 == (hdr_bits = Z zfp_write_header(dummy_zstr, dummy_field, ZFP_HEADER_FULL)))
         H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_CANTINIT, 0, "unable to write header");
 
+    /* Flush the ZFP stream */
+    zfp_stream_flush(dummy_zstr);
+
     /* compute necessary hdr_cd_values size */
     hdr_bytes     = 1 + ((hdr_bits  - 1) / 8);
     hdr_cd_nelmts = 1 + ((hdr_bytes - 1) / sizeof(hdr_cd_values[0]));


### PR DESCRIPTION
Not doing so may leave parameter bits unwritten. Many thanks to Peter Lindstrom (@lindstro) for finding this bug.

Closes #1