### PR TITLE
adding GNU Make DESTDIR support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,12 +51,12 @@ lib: $(LIBOBJ)
 all: lib plugin
 
 install: all
-	$(INSTALL) -d $(PREFIX)/{plugin,include,lib}
-	$(INSTALL) plugin/libh5zzfp.$(SOEXT) $(PREFIX)/plugin
-	$(INSTALL) libh5zzfp.a $(PREFIX)/lib
-	$(INSTALL) -m 644 H5Zzfp.h H5Zzfp_lib.h H5Zzfp_plugin.h H5Zzfp_props.h $(PREFIX)/include
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/{plugin,include,lib}
+	$(INSTALL) plugin/libh5zzfp.$(SOEXT) $(DESTDIR)$(PREFIX)/plugin
+	$(INSTALL) libh5zzfp.a $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -m 644 H5Zzfp.h H5Zzfp_lib.h H5Zzfp_plugin.h H5Zzfp_props.h $(DESTDIR)$(PREFIX)/include
 ifneq ($(FC),)
-	$(INSTALL) -m 644 *.[mM][oO][dD] $(PREFIX)/include
+	$(INSTALL) -m 644 *.[mM][oO][dD] $(DESTDIR)$(PREFIX)/include
 endif
 
 clean:


### PR DESCRIPTION
Small update to add GNU Make [DESTDIR](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) support.

This is primarily to facilitate this package's use within python packages.