### PR TITLE
Test and Docs update for ZFP 0.5.4

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,7 +134,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/hdf5_chunking.rst
+++ b/docs/hdf5_chunking.rst
@@ -1,10 +1,10 @@
 .. _hdf5_chunking:
 
-=============
-HDF5 Chunking
-=============
+==============
+HDF5_ Chunking
+==============
 
-HDF5's dataset chunking feature is a way to optimize data layout on disk
+HDF5_'s dataset `chunking`_ feature is a way to optimize data layout on disk
 to support partial dataset reads by downstream consumers. This is all the more
 important when compression filters are applied to datasets as it frees a consumer
 from suffering the UNcompression of an entire dataset only to read a portion.
@@ -14,45 +14,65 @@ from suffering the UNcompression of an entire dataset only to read a portion.
 ZFP Chunklets
 -------------
 
-When using HDF5 chunking with ZFP compression, it is important to account
-for the fact that ZFP does its work in tiny 4\ :sup:`d` chunklets of its
-own where `d` is the dataset dimension (_rank_ in HDF5 parlance). This means
-that that whenever possible chunking dimensions you select in HDF5 should be
-multiples of 4. When a chunk dimension is not a multiple of 4, ZFP will wind
+When using HDF5_ `chunking`_ with ZFP_ compression, it is important to account
+for the fact that ZFP_ does its work in tiny 4\ :sup:`d` chunklets of its
+own where `d` is the dataset dimension (*rank* in HDF5_ parlance). This means
+that that whenever possible `chunking`_ dimensions you select in HDF5_ should be
+multiples of 4. When a chunk_ dimension is not a multiple of 4, ZFP_ will wind
 up with partial chunklets which it will pad with useless data reducing overall
-time and space efficiency of the results. On the other hand when chunk dimensions
+time and space efficiency of the results. On the other hand when chunk_ dimensions
 are many times a multiple 4, this overhead is also likely to be negligible.
 
 -----------------------------
 More Than 3 (or 4) Dimensions
 -----------------------------
 
-Versions of ZFP 0.5.3 and older support compression in only 1,2 or 3
-dimensions. Versions of ZFP 0.5.4 and newer also support 4 dimensions.
+Versions of ZFP_ 0.5.3 and older support compression in only 1,2 or 3
+dimensions. Versions of ZFP_ 0.5.4 and newer also support 4 dimensions.
 
-What if you have a dataset with more dimensions than ZFP can compress?
-You can still use the H5Z-ZFP filter. But, in order to do so you
-are *required* to chunk the dataset [1]_. Furthermore, you must select a 
-chunk size such that no more than 3 (or 4 for ZFP 0.5.4 and newer)
+What if you have a dataset with more dimensions than ZFP_ can compress?
+You can still use the H5Z-ZFP_ filter. But, in order to do so you
+are *required* to chunk_ the dataset [1]_ . Furthermore, you must select a 
+chunk_ size such that no more than 3 (or 4 for ZFP_ 0.5.4 and newer)
 dimensions are non-unitary (e.g. of size one). 
 
-What analysis process should you use to select the chunk shape? Depending
+What analysis process should you use to select the chunk_ shape? Depending
 on what you expect in the way of access patters in downstream consumers,
 this can be a challenging question to answer. There are potentially two
-competing interests. One is optimizing the chunk size and shape for access
-patterns anticipated by downstream consumers. The other is optimizing the chunk
+competing interests. One is optimizing the chunk_ size and shape for access
+patterns anticipated by downstream consumers. The other is optimizing the chunk_
 size and shape for compression. These two interests may not be compatible
 and you may have to compromise between them. We illustrate the issues and
 tradeoffs using an example.
 
 For example, suppose you have a tensor valued field (e.g. a 3x3 matrix
-at every _point_) over a 4D (3 spatial dimensions and 1 time dimension),
+at every *point*) over a 4D (3 spatial dimensions and 1 time dimension),
 regularly sampled domain? Conceptually, this is a 6 dimensional dataset
-in HDF5 with one of the dimensions (the _time_ dimension) _extendible_.
-You are free to define this as a 6 dimensional dataset in HDF5. But, you
-will also have to chunk the dataset. You can select any chunk shape
-you want except that no more than 3 (or 4 for ZFP versions 0.5.4 and
-newer) dimensions of the chunk can be non-unity.
+in HDF5_ with one of the dimensions (the *time* dimension) *extendible*.
+You are free to define this as a 6 dimensional dataset in HDF5_. But, you
+will also have to chunk_ the dataset. You can select any chunk_ shape
+you want except that no more than 3 (or 4 for ZFP_ versions 0.5.4 and
+newer) dimensions of the chunk_ can be non-unity.
 
-.. [5] The HDF5 library currently requires dataset chunking anyways for
+In the code snipit below, we demonstrate this case. A key issue to deal
+with is that because we will use ZFP_ to compress along the time dimension,
+this forces us to keep in memory a sufficient number of timesteps to match
+ZFP_'s chunklet size of 4. The code below iterates over 9 timesteps. Each
+of the first two groups of 4 timesteps are buffered in memory. Once 4
+timesteps have been buffered, we can issue an H5Dwrite call on the 6D 
+dataset. But, notice that the chunk_ dimensions are such that only 4
+of the 6 dimensions are non-unity. This means ZFP_ will only ever see
+something to compress that is 4D.
+
+.. include:: ../test/test_write.c
+   :code: c
+   :start-line: 493
+   :end-line: 559
+   :number-lines:
+
+.. _chunking: https://support.hdfgroup.org/HDF5/doc/Advanced/Chunking/index.html
+.. _chunk: https://support.hdfgroup.org/HDF5/doc/Advanced/Chunking/index.html
+
+.. [1] The HDF5_ library currently requires dataset chunking anyways for
    any dataset that has any kind of filter applied.
+

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -9,9 +9,9 @@ uses HDF5_ `properties <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Gen
 added to the `dataset creation property list <https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#DatasetCreatePropFuncs>`_
 used when the dataset to be compressed is being created. You  can find examples  of writing
 HDF5_ data using both the
-`generic <https://github.com/LLNL/H5Z-ZFP/blob/master/test/test_write.c#L119>`_ 
+`generic <https://github.com/LLNL/H5Z-ZFP/blob/master/test/test_write.c#L263>`_ 
 and
-`properties <https://github.com/LLNL/H5Z-ZFP/blob/master/test/test_write.c#L145>`_ 
+`properties <https://github.com/LLNL/H5Z-ZFP/blob/master/test/test_write.c#L290>`__
 interfaces in
 `test_write.c <https://github.com/LLNL/H5Z-ZFP/blob/master/test/test_write.c>`_.
 

--- a/src/H5Zzfp.c
+++ b/src/H5Zzfp.c
@@ -1,24 +1,24 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* This code was based heavily on one of the HDF5 library's internal
-   filters, H5Zszip.c. The intention in so doing wasn't so much to 
-   plagerize HDF5 developers as it was to produce a code that, if
-   The HDF Group ever decided to in the future, could be easily
-   integrated with the existing HDF5 library code base. */
+/*
+This code was based heavily on one of the HDF5 library's internal
+filter, H5Zszip.c. The intention in so doing wasn't so much to 
+plagerize HDF5 developers as it was to produce a code that, if
+The HDF Group ever decided to in the future, could be easily
+integrated with the existing HDF5 library code base.
 
-/* The logic here for 'Z' and 'B' macros as well as there use within
-   the code to call ZFP library methods is due to this filter being
-   part of the Silo library but also supported as a stand-alone
-   package. In Silo, the ZFP library is embedded inside a C struct
-   to avoid pollution of the global namespace as well as collision
-   with any other implementation of ZFP a Silo executable may be
-   linked with. Calls to ZFP lib methods are preface with 'Z ' 
-   and calls to bitstream methods with 'B ' as in
+The logic here for 'Z' and 'B' macros as well as there use within
+the code to call ZFP library methods is due to this filter being
+part of the Silo library but also supported as a stand-alone
+package. In Silo, the ZFP library is embedded inside a C struct
+to avoid pollution of the global namespace as well as collision
+with any other implementation of ZFP a Silo executable may be
+linked with. Calls to ZFP lib methods are preface with 'Z ' 
+and calls to bitstream methods with 'B ' as in
 
-       Z zfp_stream_open(...);
-       B sream_open(...);
-
+    Z zfp_stream_open(...);
+    B stream_open(...);
 */
 
 #ifdef Z

--- a/test/Makefile
+++ b/test/Makefile
@@ -170,7 +170,7 @@ test-h5repack: plugin mesh.h5 patch
 # We should test return code but h5diff's return code has been unreliable across
 # versions and so am not relying on it here.
 test-endian: plugin test_zfp_le.h5 test_zfp_be.h5
-	outerr=$$(env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/h5diff -v -d 0.00001 test_zfp_le.h5 test_zfp_be.h5 compressed compressed 2>&1); \
+	@outerr=$$(env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/h5diff -v -d 0.00001 test_zfp_le.h5 test_zfp_be.h5 compressed compressed 2>&1); \
 	if [[ -z "$$(echo $$outerr | grep '0 differences found')" ]]; then \
 	    echo "Endian test failed"; \
 	    exit 1; \

--- a/test/test_write.c
+++ b/test/test_write.c
@@ -513,6 +513,9 @@ int main(int argc, char **argv)
         /* Generate a single buffer which we'll modulate by a time-varying function
            to represent each timestep */
         buf = gen_random_correlated_array(TYPDBL, 5, dims, 2, ucdims);
+
+        /* Allocate the "time" buffer where we will buffer up each time step
+           until we have enough to span a width of 4 */
         tbuf = malloc(31*31*31*3*3*4*sizeof(double));
 
         /* Iterate, writing 9 timesteps by buffering in time 4x. The last

--- a/test/test_write.c
+++ b/test/test_write.c
@@ -29,6 +29,13 @@ https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE
 #define NAME_LEN 256
 
 /* convenience macro to handle command-line args and help */
+#define HANDLE_SEP(SEPSTR)                                      \
+{                                                               \
+    char tmpstr[64];                                            \
+    int len = snprintf(tmpstr, sizeof(tmpstr), "\n%s...", #SEPSTR);\
+    printf("    %*s\n",60-len,tmpstr);                          \
+}
+
 #define HANDLE_ARG(A,PARSEA,PRINTA,HELPSTR)                     \
 {                                                               \
     int i;                                                      \
@@ -232,6 +239,48 @@ gen_random_correlated_array(int typ, int ndims, int const *dims, int nucdims, in
     return buf0;
 }
 
+static void
+modulate_by_time(void *data, int typ, int ndims, int const *dims, int t)
+{
+    int i, n;
+
+    for (i = 0, n = 1; i < ndims; i++)
+        n *= dims[i];
+
+    if (typ == TYPINT)
+    {
+        int *p = (int *) data;
+        for (i = 0; i < n; i++, p++)
+        {
+            double val = *p;
+            val *= exp(0.1*t*sin(t/9.0*2*M_PI));
+            *p = val;
+        }
+    }
+    else
+    {
+        double *p = (double *) data;
+        for (i = 0; i < n; i++, p++)
+        {
+            double val = *p;
+            val *= exp(0.1*t*sin(t/9.0*2*M_PI));
+            *p = val;
+        }
+    }
+}
+
+static void
+buffer_time_step(void *tbuf, void *data, int typ, int ndims, int const *dims, int t)
+{
+    int i, n;
+    int k = t % 4;
+    int nbyt = (int) (typ == TYPINT ? sizeof(int) : sizeof(double)); 
+
+    for (i = 0, n = 1; i < ndims; i++)
+        n *= dims[i];
+
+    memcpy((char*)tbuf+k*n*nbyt, data, n*nbyt);
+}
 
 static int read_data(char const *fname, size_t npoints, double **_buf)
 {
@@ -307,7 +356,6 @@ int main(int argc, char **argv)
 
     /* filename variables */
     char *ifile = (char *) calloc(NAME_LEN,sizeof(char));
-    char *ids   = (char *) calloc(NAME_LEN,sizeof(char));
     char *ofile = (char *) calloc(NAME_LEN,sizeof(char));
 
     /* sinusoid data generation variables */
@@ -316,6 +364,7 @@ int main(int argc, char **argv)
     double amp = 17.7;
     int doint = 0;
     int highd = 0;
+    int sixd = 0;
     int help = 0;
 
     /* compression parameters (defaults taken from ZFP header) */
@@ -337,18 +386,18 @@ int main(int argc, char **argv)
     /* file arguments */
     strcpy(ofile, "test_zfp.h5");
     HANDLE_ARG(ifile,strndup(argv[i]+len2,NAME_LEN), "\"%s\"",set input filename);
-    /*HANDLE_ARG(ids,strndup(argv[i]+len2,NAME_LEN), "\"%s\"",set input datast name);*/
     HANDLE_ARG(ofile,strndup(argv[i]+len2,NAME_LEN), "\"%s\"",set output filename);
 
-    /* data generation arguments */
-    HANDLE_ARG(npoints,(hsize_t) strtol(argv[i]+len2,0,10), "%llu",set number of points for generated dataset);
-    HANDLE_ARG(noise,(double) strtod(argv[i]+len2,0),"%g",set amount of random noise in generated dataset);
-    HANDLE_ARG(amp,(double) strtod(argv[i]+len2,0),"%g",set amplitude of sinusoid in generated dataset);
-    HANDLE_ARG(doint,(int) strtol(argv[i]+len2,0,10),"%d",also do integer data);
-    HANDLE_ARG(highd,(int) strtol(argv[i]+len2,0,10),"%d",run high-dimensional (>3D) case);
+    /* 1D dataset arguments */
+    HANDLE_SEP(1D dataset generation arguments)
+    HANDLE_ARG(npoints,(hsize_t) strtol(argv[i]+len2,0,10), "%llu",set number of points for 1D dataset);
+    HANDLE_ARG(noise,(double) strtod(argv[i]+len2,0),"%g",set amount of random noise in 1D dataset);
+    HANDLE_ARG(amp,(double) strtod(argv[i]+len2,0),"%g",set amplitude of sinusoid in 1D dataset);
+    HANDLE_ARG(chunk,(hsize_t) strtol(argv[i]+len2,0,10), "%llu",set chunk size for 1D dataset);
+    HANDLE_ARG(doint,(int) strtol(argv[i]+len2,0,10),"%d",also do integer 1D data);
 
-    /* HDF5 chunking and ZFP filter arguments */
-    HANDLE_ARG(chunk,(hsize_t) strtol(argv[i]+len2,0,10), "%llu",set chunk size for dataset);
+    /* ZFP filter arguments */
+    HANDLE_SEP(ZFP compression paramaters)
     HANDLE_ARG(zfpmode,(int) strtol(argv[i]+len2,0,10),"%d",set zfp mode (1=rate,2=prec,3=acc,4=expert)); 
     HANDLE_ARG(rate,(double) strtod(argv[i]+len2,0),"%g",set rate for rate mode of filter);
     HANDLE_ARG(acc,(double) strtod(argv[i]+len2,0),"%g",set accuracy for accuracy mode of filter);
@@ -357,6 +406,12 @@ int main(int argc, char **argv)
     HANDLE_ARG(maxbits,(uint) strtol(argv[i]+len2,0,10),"%u",set maxbits for expert mode of zfp filter);
     HANDLE_ARG(maxprec,(uint) strtol(argv[i]+len2,0,10),"%u",set maxprec for expert mode of zfp filter);
     HANDLE_ARG(minexp,(int) strtol(argv[i]+len2,0,10),"%d",set minexp for expert mode of zfp filter);
+
+    /* Advanced cases */
+    HANDLE_SEP(Advanced cases)
+    HANDLE_ARG(highd,(int) strtol(argv[i]+len2,0,10),"%d",run 4D case);
+    HANDLE_ARG(sixd,(int) strtol(argv[i]+len2,0,10),"%d",run 6D extendable case (requires ZFP>=0.5.4));
+
     cpid = setup_filter(1, &chunk, zfpmode, rate, acc, prec, minbits, maxbits, maxprec, minexp);
     /* Put this after setup_filter to permit printing of otherwise hard to 
        construct cd_values to facilitate manual invokation of h5repack */
@@ -409,7 +464,8 @@ int main(int argc, char **argv)
     /* Test high dimensional (>3D) array */
     if (highd)
     {
-        int fd, dims[] = {128,128,16,32}, ucdims[]={1,3};
+        int fd, dims[] = {128,128,16,32};
+        int ucdims[]={1,3}; /* indices of the UNcorrleted dimensions in dims */
         hsize_t hdims[] = {128,128,16,32};
         hsize_t hchunk[] = {1,128,1,32};
 
@@ -435,11 +491,77 @@ int main(int argc, char **argv)
         free(buf);
     }
 
+    /* Test six dimensional, time varying array...a 3x3 tensor valued variable
+       over a 3D+time domain. Dimension sizes are chosen to miss perfect ZFP block 
+       alignment. */
+    if (sixd)
+    {
+        void *tbuf;
+        int t, fd, dims[] = {31,31,31,3,3}; /* a single time instance */
+        int ucdims[]={3,4}; /* indices of UNcorrleted dimensions in dims (tensor components) */
+        hsize_t  hdims[] = {31,31,31,3,3,H5S_UNLIMITED};
+        hsize_t hchunk[] = {31,31,31,1,1,4}; /* 4 non-unity, requires >= ZFP 0.5.4 */
+        hsize_t hwrite[] = {31,31,31,3,3,4}; /* size/shape of any given H5Dwrite */
+
+        /* Setup the filter properties and create the dataset */
+        cpid = setup_filter(6, hchunk, zfpmode, rate, acc, prec, minbits, maxbits, maxprec, minexp);
+        if (0 > (sid = H5Screate_simple(6, hwrite, hdims))) ERROR(H5Screate_simple);
+        if (0 > (dsid = H5Dcreate(fid, "6D_extendible", H5T_NATIVE_DOUBLE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) ERROR(H5Dcreate);
+        if (0 > H5Sclose(sid)) ERROR(H5Sclose);
+        if (0 > H5Pclose(cpid)) ERROR(H5Pclose);
+
+        /* Generate a single buffer which we'll modulate by a time-varying function
+           to represent each timestep */
+        buf = gen_random_correlated_array(TYPDBL, 5, dims, 2, ucdims);
+        tbuf = malloc(31*31*31*3*3*4*sizeof(double));
+
+        /* Iterate, writing 9 timesteps by buffering in time 4x. The last
+           write will contain just one timestep causing ZFP to wind up 
+           padding all those blocks by 3x along the time dimension.  */
+        for (t = 1; t < 5; t++)
+        {
+            hid_t msid, fsid;
+            hsize_t hstart[] = {0,0,0,0,0,t-4}; /* size/shape of any given H5Dwrite */
+            hsize_t hcount[] = {31,31,31,3,3,4}; /* size/shape of any given H5Dwrite */
+
+            /* Update (e.g. modulate) the buf data for the current time step */
+            modulate_by_time(buf, TYPDBL, 5, dims, t);
+
+            /* Buffer this timestep in memory. Since chunk size in time dimension is 4,
+               we need to buffer up 4 time steps before we can issue any writes */ 
+            buffer_time_step(tbuf, buf, TYPDBL, 5, dims, t);
+
+            /* If the buffer isn't full, just continue updating it */
+            if (t%4 && t!=9) continue;
+
+            /* Define the memory dataspace to use for this H5Dwrite call */
+            if (t == 9)
+            {
+                /* last timestep, write a partial buffer */
+                hwrite[5] = 1;
+                hcount[5] = 1;
+            }
+
+            if (0 > (msid = H5Screate_simple(6, hwrite, 0))) ERROR(H5Screate_simple);
+
+            /* Get the file dataspace to use for this H5Dwrite call */
+            if (0 > (fsid = H5Dget_space(dsid))) ERROR(H5Dget_space);
+            if (0 > H5Sselect_hyperslab(fsid, H5S_SELECT_SET, hstart, 0, hcount, 0)) ERROR(H5Sselect_hyperslab);
+
+            /* Write this iteration to the dataset */
+            if (0 > H5Dwrite(dsid, H5T_NATIVE_DOUBLE, msid, fsid, H5P_DEFAULT, tbuf)) ERROR(H5Dwrite);
+            if (0 > H5Sclose(msid)) ERROR(H5Sclose);
+            if (0 > H5Sclose(fsid)) ERROR(H5Sclose);
+        }
+        if (0 > H5Dclose(dsid)) ERROR(H5Dclose);
+        free(buf);
+        free(tbuf);
+    }
+
     if (0 > H5Fclose(fid)) ERROR(H5Fclose);
 
     free(ifile);
     free(ofile);
-    free(ids);
 
 #ifndef H5Z_ZFP_USE_PLUGIN
     /* When filter is used as a library, we need to finalize it */


### PR DESCRIPTION
- Added an example of a 6D dataset
  - A time-varying 3x3 tensor field defined over a 3D spatial domain
  - 3 spatial dimensions, 1 time dimension, 2 _value_ dimensions
  - Time dimension is _extendible_
  - Uses ZFP to compress 4D including the time dimension
- Added documentation about chunking issues