### PR TITLE
Remove include for HDF5 header file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - pwd
   - ls
   - pushd /tmp
-  - wget http://computation.llnl.gov/projects/floating-point-compression/download/zfp-0.5.5.tar.gz
+  - wget https://computing.llnl.gov/projects/zfp/download/zfp-0.5.5.tar.gz
   - tar -xzf zfp-0.5.5.tar.gz
   - pushd zfp-0.5.5
   - make DEFS=-DBIT_STREAM_WORD_TYPE=uint8

--- a/src/H5Zzfp_props.h
+++ b/src/H5Zzfp_props.h
@@ -1,8 +1,6 @@
 #ifndef H5Z_ZFP_PROPS_H
 #define H5Z_ZFP_PROPS_H
 
-#include "hdf5.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The prop functions cannot really ever be used in the absence of an `hdf5.h` header file. And, I don't want using them to inadvertently include `hdf5.h` for someone if they were not expecting it. So, I've removed it. here.