### PR TITLE
find zfp and hdf5 in lib64 instead of lib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,69 @@
+name: h5z-zfp
+
+# Controls when the action will run. 
+#Triggers the workflow on push or pull requests.
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that
+# can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    strategy:
+      matrix:
+        name: ["Ubuntu Latest GCC"]
+        include:
+          - name: "Ubuntu Latest GCC"
+            artifact: "Linux.tar.xz"
+            os: ubuntu-latest
+
+    name: ${{ matrix.name }}
+    # The type of runner that the job will run on.
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+
+    # Steps represent a sequence of tasks that will be executed 
+    # as part of the job.
+    steps:
+    - name: Install Dependencies (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install -qq libhdf5-dev
+        sudo apt-get install -qq hdf5-tools
+        echo  "HDF5_HOME=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial,/usr/bin" >> $GITHUB_ENV
+        # Set env vars
+        echo "CC=gcc" >> $GITHUB_ENV
+        echo "FC=gfortran" >> $GITHUB_ENV
+        echo "CXX=g++"  >> $GITHUB_ENV
+        
+ # Checks-out the repository under $GITHUB_WORKSPACE so the job can access it.
+    - name: Get Sources
+      uses: actions/checkout@v2
+
+##################################
+# INSTALL ZFP
+##################################
+                 
+    - name: install ZFP
+      run: |
+        git clone https://github.com/LLNL/zfp.git
+        export HOME_DIR=$(echo ~)
+        cd zfp
+        export DEFS="-DBIT_STREAM_WORD_TYPE=uint8"
+        make
+        echo "ZFP_HOME=$PWD" >> $GITHUB_ENV
+      shell: bash
+
+##################################
+# BUILD AND TEST H5Z-ZFP
+##################################
+
+    - name: build and check
+      run: |
+        make all
+        make check
+      shell: bash

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ help:
 	@echo "    make CC=<C-compiler> HDF5_HOME=<path> ZFP_HOME=<path> PREFIX=<path> all"
 	@echo ""
 	@echo "where <path> is a dir whose children are include/lib/bin subdirs."
+	@echo "HDF5_HOME can also be specified by the HDF5 include directory,"
+	@echo "library directory and bin directory separated by commas, i.e. HDF5_HOME=INC,LIB,BIN"
 	@echo "Standard make variables (e.g. CFLAGS, LD, etc.) can be set as usual."
 	@echo "Optionally, add FC=<fortran-compiler> to include Fortran support and tests."
 	@echo ""

--- a/config.make
+++ b/config.make
@@ -128,18 +128,38 @@ ZFP_INC = $(ZFP_HOME)/inc
 else
 ZFP_INC = $(ZFP_HOME)/include
 endif
+ifeq ($(wildcard $(ZFP_HOME)/lib),)
+ZFP_LIB = $(ZFP_HOME)/lib64
+else
 ZFP_LIB = $(ZFP_HOME)/lib
+endif
 
-HDF5_INC = $(HDF5_HOME)/include
-HDF5_LIB = $(HDF5_HOME)/lib
-HDF5_BIN = $(HDF5_HOME)/bin
+# Check if specified individually the HDF5 include directory,
+# library directory and bin directory separated by commas, i.e. HDF5_HOME=INC,LIB,BIN
+
+ifneq (,$(findstring ",",$(HDF5_HOME)))
+  HDF5_INC = $(shell echo $(HDF5_HOME) | awk -F'[,]' '{print $$1}')
+  HDF5_LIB = $(shell echo $(HDF5_HOME) | awk -F'[,]' '{print $$2}')
+  HDF5_BIN = $(shell echo $(HDF5_HOME) | awk -F'[,]' '{print $$3}')
+  MAKEVARS =
+else
+
+  HDF5_INC = $(HDF5_HOME)/include
+  ifeq ($(wildcard $(HDF5_HOME)/lib),)
+    HDF5_LIB = $(HDF5_HOME)/lib64
+  else
+    HDF5_LIB = $(HDF5_HOME)/lib
+  endif
+  HDF5_BIN = $(HDF5_HOME)/bin
+  MAKEVARS = HDF5_HOME=$(HDF5_HOME)
+endif
 
 ifeq ($(PREFIX),)
     PREFIX := $(shell pwd)/install
 endif
 INSTALL ?= install
 
-MAKEVARS = ZFP_HOME=$(ZFP_HOME) HDF5_HOME=$(HDF5_HOME) PREFIX=$(PREFIX)
+MAKEVARS += ZFP_HOME=$(ZFP_HOME)  PREFIX=$(PREFIX)
 
 .SUFFIXES:
 .SUFFIXES: .c .F90 .h .o .mod

--- a/config.make
+++ b/config.make
@@ -143,7 +143,6 @@ ifneq (,$(findstring ",",$(HDF5_HOME)))
   HDF5_BIN = $(shell echo $(HDF5_HOME) | awk -F'[,]' '{print $$3}')
   MAKEVARS =
 else
-
   HDF5_INC = $(HDF5_HOME)/include
   ifeq ($(wildcard $(HDF5_HOME)/lib),)
     HDF5_LIB = $(HDF5_HOME)/lib64

--- a/test/Makefile
+++ b/test/Makefile
@@ -65,6 +65,11 @@ test-rate-f: plugin test_rw_fortran
 	@for r in 32 16 8 4; do\
 	    expected_ratio=$$(expr 64 \/ $$r); \
 	    ./test_rw_fortran zfpmode 1 rate $$r 2>&1 1>/dev/null; \
+            status=$$?; \
+            if [[ $$status -ne 0 ]]; then \
+	        echo "Fortran rate test failed for rate=$$r"; \
+	        exit 1; \
+            fi; \
 	    actual_ratio=$$(env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/h5dump -H -d compressed -p test_zfp_fortran.h5 | grep COMPRESSION | cut -d':' -f1 | cut -d'(' -f2 | cut -d'.' -f1); \
 	    if [[ $$expected_ratio -ne $$actual_ratio ]]; then \
 	        echo "Fortran rate test failed for rate=$$r"; \
@@ -77,6 +82,11 @@ test-rate-f: plugin test_rw_fortran
 test-accuracy-f: plugin test_rw_fortran
 	@for a in 0.1 0.01 0.001 0.0001; do\
 	    ./test_rw_fortran zfpmode 3 acc $$a write_only 2>&1 1>/dev/null; \
+            status=$$?; \
+            if [[ $$status -ne 0 ]]; then \
+	        echo "Fortran accuracy test failed for accuracy=$$a"; \
+	        exit 1; \
+            fi; \
 	    env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/h5diff -v -d $$a test_zfp_fortran.h5 test_zfp_fortran.h5 compressed original 2>&1 1>/dev/null; \
 	    if [[ $$? -ne 0 ]]; then \
 	        echo "Fortran accuracy test failed for accuracy=$$a"; \
@@ -90,6 +100,11 @@ test-precision-f: plugin test_rw_fortran
 	@ldiffcnt=0; \
 	for p in 12 16 20 24; do\
 	    ./test_rw_fortran zfpmode 2 prec $$p write_only 2>&1 1>/dev/null; \
+            status=$$?; \
+            if [[ $$status -ne 0 ]]; then \
+	        echo "Fortran precision test failed for precision=$$p"; \
+	        exit 1; \
+            fi; \
 	    diffcnt=$$(env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/h5diff -v -p 0.00001 test_zfp_fortran.h5 test_zfp_fortran.h5 compressed original | grep 'differences found' | cut -d' ' -f1); \
 	    if [[ $$ldiffcnt -ne 0 ]] && [[ $$diffcnt -gt $$ldiffcnt ]]; then \
 	        echo "Fortran precision test failed for precision=$$p"; \
@@ -102,6 +117,11 @@ test-precision-f: plugin test_rw_fortran
 # Ensure reversible gives bit-for-bit identical results
 test-reversible-f: plugin test_rw_fortran
 	@./test_rw_fortran zfpmode 5 write_only 2>&1 1>/dev/null; \
+        status=$$?; \
+        if [[ $$status -ne 0 ]]; then \
+	    echo "Fortran precision test failed for precision=$$p"; \
+            exit 1; \
+         fi; \
 	diffcnt=$$(env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/h5diff -v -p 0.00001 test_zfp_fortran.h5 test_zfp_fortran.h5 compressed original | grep 'differences found' | cut -d' ' -f1); \
 	if [[ $$diffcnt -ne 0 ]]; then \
 	    echo "Fortran Reversible test failed"; \

--- a/test/test_rw_fortran.F90
+++ b/test/test_rw_fortran.F90
@@ -74,34 +74,34 @@ PROGRAM main
      CALL GET_COMMAND_ARGUMENT(i,arg,len,status)
      IF (status .NE. 0) THEN
         WRITE (*,*) 'get_command_argument failed: status = ', status, ' arg = ', i
-        STOP
+        STOP 1
      END IF
      IF(arg(1:len).EQ.'zfpmode') THEN
         CALL GET_COMMAND_ARGUMENT(i+1,arg,len,status)
         IF (status .NE. 0) THEN
            WRITE (*,*) 'get_command_argument failed: status = ', status, ' arg = ', i
-           STOP
+           STOP 1
         END IF
         READ(arg(1:len), *) zfpmode
      ELSE IF (arg(1:len).EQ.'rate')THEN
         CALL GET_COMMAND_ARGUMENT(i+1,arg,len,status)
         IF (status .NE. 0) THEN
            WRITE (*,*) 'get_command_argument failed: status = ', status, ' arg = ', i
-           STOP
+           STOP 1
         END IF
         READ(arg(1:len), *) rate
      ELSE IF (arg(1:len).EQ.'acc')THEN
         CALL GET_COMMAND_ARGUMENT(i+1,arg,len,status)
         IF (status .NE. 0) THEN
            WRITE (*,*) 'get_command_argument failed: status = ', status, ' arg = ', i
-           STOP
+           STOP 1
         END IF
         READ(arg(1:len), *) acc
      ELSE IF (arg(1:len).EQ.'prec')THEN
         CALL GET_COMMAND_ARGUMENT(i+1,arg,len,status)
         IF (status .NE. 0) THEN
            WRITE (*,*) 'get_command_argument failed: status = ', status, ' arg = ', i
-           STOP
+           STOP 1
         END IF
         READ(arg(1:len), *) prec
      ELSE IF (arg(1:len).EQ.'write')THEN
@@ -114,7 +114,7 @@ PROGRAM main
         PRINT*,"acc <val>     - set accuracy for accuracy mode of filter"
         PRINT*,"prec <val>    - set PRECISION for PRECISION mode of zfp filter"
         PRINT*,"write         - only write the file"
-        STOP
+        STOP 1
      ENDIF
       
   END DO
@@ -275,7 +275,7 @@ PROGRAM main
          
          IF (absdiff > max_absdiff) max_absdiff = absdiff
          IF (reldiff > max_reldiff) max_reldiff = reldiff
-         IF( .NOT.real_eq(obuf(j), cbuf(j), 200) ) THEN
+         IF( .NOT.real_eq(obuf(j), cbuf(j), 2000) ) THEN
             num_diffs = num_diffs + 1
          ENDIF
       ENDIF
@@ -285,8 +285,10 @@ PROGRAM main
       WRITE(*,'(A)') "Fortran read/write test Failed"
       WRITE(*,'(I0," values are different; max-absdiff = ",E15.8,", max-reldiff = ",E15.8)')  &
            num_diffs,max_absdiff, max_reldiff
+      STOP 1
    ELSE IF(nerr.NE.0)THEN
       WRITE(*,'(A)') "Fortran read/write test Failed"
+      STOP 1
    ELSE
       WRITE(*,'(A)') "Fortran read/write test Passed"
    ENDIF
@@ -318,10 +320,10 @@ SUBROUTINE gen_data(npoints, noise, amp, buf)
   pi = 4.0_C_DOUBLE*ATAN(1.0_C_DOUBLE)
 
   DO i = 1, npoints
-     rand = i
+     rand = REAL(i, C_DOUBLE)
      CALL RANDOM_NUMBER(rand)
      x = 2_c_double * pi * REAL(i-1, C_DOUBLE) / REAL(npoints-1, C_DOUBLE)
-     buf(i) = amp*( 1_C_DOUBLE + SIN(x)) + (rand - 0.5)*noise
+     buf(i) = amp*( 1.0_C_DOUBLE + SIN(x)) + (rand - 0.5_C_DOUBLE)*noise
   ENDDO
 
 END SUBROUTINE gen_data

--- a/test/test_rw_fortran.F90
+++ b/test/test_rw_fortran.F90
@@ -35,8 +35,8 @@ PROGRAM main
   INTEGER(C_SIZE_T) :: cd_nelmts = H5Z_ZFP_CD_NELMTS_MEM
 
   ! compressed/uncompressed difference stat variables 
-  REAL(dp) :: max_absdiff = 0
-  REAL(dp) :: max_reldiff = 0
+  REAL(dp) :: max_absdiff = 0.0_dp
+  REAL(dp) :: max_reldiff = 0.0_dp
   INTEGER(C_INT) :: num_diffs = 0
 
   REAL(dp) :: noise = 0.001
@@ -275,8 +275,7 @@ PROGRAM main
          
          IF (absdiff > max_absdiff) max_absdiff = absdiff
          IF (reldiff > max_reldiff) max_reldiff = reldiff
-
-         IF( .NOT.real_eq(obuf(j), cbuf(j), 125) ) THEN
+         IF( .NOT.real_eq(obuf(j), cbuf(j), 200) ) THEN
             num_diffs = num_diffs + 1
          ENDIF
       ENDIF


### PR DESCRIPTION
Search for hdf5 and zfp  in lib64 instead of lib if lib is not present (SuSE builds)

Also, zfp master is using ZFP_BIT_STREAM_WORD_SIZE instead of BIT_STREAM_WORD_TYPE, so that might need to be documented and the error code message updated in the future.

ZFP_BIT_STREAM_WORD_SIZE=8