### PR TITLE
Add missing headers for string functions and fix printfs for cd_nelmts

### DIFF
--- a/test/test_error.c
+++ b/test/test_error.c
@@ -14,6 +14,7 @@ https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <strings.h>
 #include <unistd.h>
 

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -15,6 +15,7 @@ https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#define _GNU_SOURCE
 #include <strings.h>
 #include <unistd.h>
 

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -8,7 +8,7 @@ This file is part of H5Z-ZFP. Please also read the BSD license
 https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE 
 */
 
-#define _GNU_SOURCE
+#define _GNU_SOURCE /* ahead of ALL headers to take proper effect */
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -138,7 +138,7 @@ static int walk_hdf5_error_stack_cb(unsigned int n, H5E_error_t const *err_desc,
 {   
     client_data_t *cd  = (client_data_t *) _cd;
     if (n > 0) return 0;
-    cd->has_str = (strcasestr(err_desc->desc, cd->str) != 0);
+    cd->has_str = strcasestr(err_desc->desc, cd->str) != 0;
     return 0;
 }
 

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -8,19 +8,16 @@ This file is part of H5Z-ZFP. Please also read the BSD license
 https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE 
 */
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#define _GNU_SOURCE
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
-
-#define _GNU_SOURCE
-#include <string.h>
 
 #include "hdf5.h"
 

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -14,6 +14,7 @@ https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <unistd.h>
 
 #define _GNU_SOURCE

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -16,7 +16,6 @@ https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE
 #include <stdlib.h>
 #define _GNU_SOURCE
 #include <string.h>
-#undef _GNU_SOURCE
 #include <strings.h>
 #include <unistd.h>
 

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -14,8 +14,9 @@ https://raw.githubusercontent.com/LLNL/H5Z-ZFP/master/LICENSE
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #define _GNU_SOURCE
+#include <string.h>
+#undef _GNU_SOURCE
 #include <strings.h>
 #include <unistd.h>
 

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -141,7 +141,7 @@ static int walk_hdf5_error_stack_cb(unsigned int n, H5E_error_t const *err_desc,
 {   
     client_data_t *cd  = (client_data_t *) _cd;
     if (n > 0) return 0;
-    cd->has_str = strcasestr(err_desc->desc, cd->str) != 0;
+    cd->has_str = (strcasestr(err_desc->desc, cd->str) != 0);
     return 0;
 }
 

--- a/test/test_write.c
+++ b/test/test_write.c
@@ -323,8 +323,8 @@ static hid_t setup_filter(int n, hsize_t *chunk, int zfpmode,
         cd_nelmts = 0; /* causes default behavior of ZFP library */
 
     /* print cd-values array used for filter */
-    printf("%d cd_values= ",cd_nelmts);
-    for (i = 0; i < cd_nelmts; i++)
+    printf("%d cd_values= ", (int) cd_nelmts);
+    for (i = 0; i < (int) cd_nelmts; i++)
         printf("%u,", cd_values[i]);
     printf("\n");
 


### PR DESCRIPTION
Happened to see this in GHA logs (thanks to @brtnfld ;) So fixing it here.