### PR TITLE
Use ZFP's version string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,8 +106,10 @@ jobs:
       - name: Download and install ZFP
         run: |
           git clone https://github.com/LLNL/zfp.git
-          mkdir -p zfp/build
-          cd zfp/build
+          cd zfp
+          git checkout 0.5.5
+          mkdir -p build
+          cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_UTILITIES=OFF \

--- a/config.make
+++ b/config.make
@@ -20,7 +20,10 @@ endif
 
 H5Z_ZFP_PLUGIN := $(H5Z_ZFP_BASE)/plugin
 H5Z_ZFP_VERSINFO := $(shell grep '^\#define H5Z_FILTER_ZFP_VERSION_[MP]' $(H5Z_ZFP_BASE)/H5Zzfp_plugin.h | cut -d' ' -f3 | tr '\n' '.' | cut -d'.' -f-3 2>/dev/null)
+ZFP_HAS_REVERSIBLE :=
+ifneq ($(ZFP_HOME),)
 ZFP_HAS_REVERSIBLE := $(shell grep zfp_stream_set_reversible $(ZFP_HOME)/include/zfp.h)
+endif
 
 # Detect system type
 PROCESSOR := $(shell uname -p | tr '[:upper:]' '[:lower:]')

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -164,21 +164,19 @@ The source code is in two separate directories
 Silo Integration
 ----------------
 
-This filter is also built-in to the `Silo library <https://wci.llnl.gov/simulation/computer-codes/silo>`_.
-In particular, the ZFP_ library
-itself is also embedded in Silo but is protected from appearing in Silo's
-global namespace through a struct of function pointers (see `Namespaces in C) <https://github.com/markcmiller86/silo-issues/wiki/Using-C-structs-as-a-kind-of-namespace-mechanism-to-reduce-global-symbol-bloat>`_.
-If you happen to examine the source code for H5Z-ZFP_, you will see some logic there
-that is specific to using this plugin within Silo and dealing with ZFP_ as an embedded
-library using this struct of function pointers wrapper. In the source code for H5Z-ZFP_ this will manifest as something like is shown in the code below... 
+This filter (``H5Zzfp.c``) is also built-in to the `Silo library <https://wci.llnl.gov/simulation/computer-codes/silo>`_.
+In particular, the ZFP_ library itself is also embedded in Silo but is protected from appearing in Silo's global namespace through a struct of function pointers (see `Namespaces in C) <https://github.com/markcmiller86/silo-issues/wiki/Using-C-structs-as-a-kind-of-namespace-mechanism-to-reduce-global-symbol-bloat>`_.
+If you happen to examine the source code here for H5Z-ZFP_, you will see some logic here that is specific to using this plugin within Silo and dealing with ZFP_ as an embedded library using this struct of function pointers wrapper.
+In the source code for H5Z-ZFP_ this manifests as something like is shown in the code snippet below... 
 
-literalinclude:: ../src/H5Zzfp.c
+.. literalinclude:: ../src/H5Zzfp.c
    :language: c
    :linenos:
    :start-after: /* set up dummy zfp field to compute meta header */
    :end-before:  if (!dummy_field)
    
- In the code snipit above, note the funny ``Z `` in front of calls to various methods in the ZFP_ library.
- Depending upon whether the code is compiled with ``-DAS_SILO_BUILTIN`` that ``Z `` resolves to either the empty string of the name of a struct and struct-member dereferncing operator as in ``zfp.``.
- There is a similar ``B `` used ahead of calls to ZFP_'s bitstream library.
- This is something to be aware of and to adhere to if you plan to contribute any code changes here.
+In the code snippet above, note the funny ``Z `` in front of calls to various methods in the ZFP_ library.
+When compiling H5Z_ZFP_ normally, that ``Z `` normally resolves to the empty string.
+But, when the code is compiled with ``-DAS_SILO_BUILTIN`` (which is supported and should be done *only* when ``H5Zzfp.c`` is being compiled *within* the Silo library and *next to* a version of ZFP_ that is embedded in Silo) that ``Z `` resolves to the name of a struct and struct-member dereferncing operator as in ``zfp.``.
+There is a similar ``B `` used for a similar purpose ahead of calls to ZFP_'s bitstream library.
+This is something to be aware of and to adhere to if you plan to contribute any code changes here.

--- a/src/H5Zzfp.c
+++ b/src/H5Zzfp.c
@@ -47,11 +47,7 @@ and calls to bitstream methods with 'B ' as in
 #include "H5Zzfp_plugin.h"
 #include "H5Zzfp_props_private.h"
 
-/* Convenient CPP logic to capture ZFP lib version numbers as compile time string and hex number */
-#define ZFP_VERSION_STR__(Maj,Min,Rel) #Maj "." #Min "." #Rel
-#define ZFP_VERSION_STR_(Maj,Min,Rel)  ZFP_VERSION_STR__(Maj,Min,Rel)
-#define ZFP_VERSION_STR                ZFP_VERSION_STR_(ZFP_VERSION_MAJOR,ZFP_VERSION_MINOR,ZFP_VERSION_RELEASE)
-
+/* Convenient CPP logic to capture ZFP lib version numbers as compile time hex number */
 #define ZFP_VERSION_NO__(Maj,Min,Rel)  (0x0 ## Maj ## Min ## Rel)
 #define ZFP_VERSION_NO_(Maj,Min,Rel)   ZFP_VERSION_NO__(Maj,Min,Rel)
 #define ZFP_VERSION_NO                 ZFP_VERSION_NO_(ZFP_VERSION_MAJOR,ZFP_VERSION_MINOR,ZFP_VERSION_RELEASE)
@@ -90,7 +86,7 @@ const H5Z_class2_t H5Z_ZFP[1] = {{
     1,                      /* decoder_present flag         */
     "H5Z-ZFP"               /* Filter name for debugging    */
     "-" H5Z_FILTER_ZFP_VERSION_STR
-    " (ZFP-" ZFP_VERSION_STR ")",
+    " (ZFP-" ZFP_VERSION_STRING ")",
     H5Z_zfp_can_apply,      /* The "can apply" callback     */
     H5Z_zfp_set_local,      /* The "set local" callback     */
     H5Z_filter_zfp,         /* The actual filter function   */
@@ -516,7 +512,7 @@ H5Z_filter_zfp(unsigned int flags, size_t cd_nelmts,
         /* Worry about zfp version and endian mismatch only for decompression */
         if (cd_vals_zfpver > ZFP_VERSION)
             H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_NOSPACE, 0, "ZFP lib version, "
-                ZFP_VERSION_STR ", too old to decompress this data");
+                ZFP_VERSION_STRING ", too old to decompress this data");
 
         /* Set up the ZFP field object */
         if (0 == (zfld = Z zfp_field_alloc()))


### PR DESCRIPTION
Superscedes #78 by removing use of `ZFP_VERSION_STR` all together.