### PR TITLE
CMake: (fix) Missing header file.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Define headers.
 set(h5z_zfp_headers
-  H5Zzfp.h H5Zzfp_lib.h H5Zzfp_plugin.h H5Zzfp_props.h)
+  H5Zzfp.h H5Zzfp_lib.h H5Zzfp_plugin.h H5Zzfp_props.h H5Zzfp_version.h)
 
 #------------------------------------------------------------------------------#
 # Static library


### PR DESCRIPTION
- Added the missing header file "H5Zzfp_version.h" to the
  h5z_zfp_headers list such it be will installed.