### PR TITLE
Compatibility with Visual Studio 2019

### DIFF
--- a/src/H5Zzfp.c
+++ b/src/H5Zzfp.c
@@ -191,10 +191,11 @@ H5Z_zfp_can_apply(hid_t dcpl_id, hid_t type_id, hid_t chunk_space_id)
     }
 
     if (ndims_used == 0 || ndims_used > max_ndims)
-        H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0,
 #if ZFP_VERSION_NO < 0x0530
+        H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0,
             "chunk must have only 1...3 non-unity dimensions");
 #else
+        H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0,
             "chunk must have only 1...4 non-unity dimensions");
 #endif
 
@@ -283,10 +284,11 @@ H5Z_zfp_set_local(hid_t dcpl_id, hid_t type_id, hid_t chunk_space_id)
 #if ZFP_VERSION_NO >= 0x0540
         case 4: dummy_field = Z zfp_field_4d(0, zt, dims_used[3], dims_used[2], dims_used[1], dims_used[0]); break;
 #endif
-        default: H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0,
 #if ZFP_VERSION_NO < 0x0530
+        default: H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0,
                      "chunks may have only 1...3 non-unity dims");
 #else
+        default: H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0,
                      "chunks may have only 1...4 non-unity dims");
 #endif
     }


### PR DESCRIPTION
It seems Visual Studio compiler has troubles with continuation lines in the middle of macros.

```
H5Zzfp.c
src/H5Z-ZFP/src\H5Zzfp.c(196): error C2121: '#': invalid character: possibly the result of a macro expansion
src/H5Z-ZFP/src\H5Zzfp.c(196): error C2059: syntax error: 'if'
src/H5Z-ZFP/src\H5Zzfp.c(197): fatal error C1019: unexpected #else
error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\14.28.29910\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
```