### PR TITLE
Don't fail the test suite when a test is skipped

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -553,7 +553,6 @@ test-int: test_write_lib test_read_lib
 	    exit 0; \
 	elif [[ $$status -eq 2 ]]; then \
 	    printf " [$(SKIP_COLOR)SKIPPED$(NO_COLOR)]\n"; \
-	    touch check-failed; \
 	    exit 0; \
 	fi; \
 	./test_read_lib ret=1 max_absdiff=2 2>&1 1>/dev/null; \
@@ -590,7 +589,6 @@ test-sixd: test_write_lib
 	status=$$?; \
 	if [[ $$status -eq 2 ]]; then \
 	    printf " [$(SKIP_COLOR)SKIPPED$(NO_COLOR)]\n"; \
-	    touch check-failed; \
 	    exit 0; \
 	elif [[ $$status -ne 0 ]]; then \
 	    printf " [$(ERROR_COLOR)FAILED$(NO_COLOR)]\n"; \
@@ -625,7 +623,6 @@ test-zfparr: test_write_lib
 	status=$$?; \
 	if [[ $$status -eq 2 ]]; then \
 	    printf " [$(SKIP_COLOR)SKIPPED$(NO_COLOR)]\n"; \
-	    touch check-failed; \
 	    exit 0; \
 	elif [[ $$status -ne 0 ]]; then \
 	    printf " [$(ERROR_COLOR)FAILED$(NO_COLOR)]\n"; \


### PR DESCRIPTION
Hello, and thank you for H5Z-ZFP.

When packaging it for Debian I noticed that the test suite fails when a test is skipped (ZFP in Debain is currently compiled without CFP), and I assume that was not the intention.

This PR should make it so that the test suite reports failure when a test fails, but not when a test is skipped.