### PR TITLE
Add cc, ftn compilers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Install Dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
+	sudo apt-get update
         sudo apt-get install -qq libhdf5-dev
         sudo apt-get install -qq hdf5-tools
         echo  "HDF5_HOME=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial,/usr/bin" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-	sudo apt-get update
+        sudo apt-get update
         sudo apt-get install -qq libhdf5-dev
         sudo apt-get install -qq hdf5-tools
         echo  "HDF5_HOME=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial,/usr/bin" >> $GITHUB_ENV

--- a/config.make
+++ b/config.make
@@ -98,6 +98,10 @@ ifneq ($(findstring gcc, $(CC)),)
     SOEXT ?= so
     SHFLAG ?= -shared
     PREPATH = -Wl,-rpath,
+else ifneq ($(findstring cc, $(CC)),)
+    CFLAGS += -fPIC
+    SOEXT ?= so
+    SHFLAG ?= -shared
 else ifneq ($(findstring clang, $(CC)),)
     SOEXT ?= dylib
     SHFLAG ?= -dynamiclib
@@ -125,6 +129,8 @@ else ifneq ($(findstring bgxlc_r, $(CC)),)
 endif
 
 ifneq ($(findstring gfortran, $(FC)),)
+    FCFLAGS += -fPIC
+else ifneq ($(findstring ftn, $(FC)),)
     FCFLAGS += -fPIC
 else ifneq ($(findstring ifort, $(FC)),)
     FCFLAGS += -fpic


### PR DESCRIPTION
There is logic in `config.make` which controls vanilla GNU make builds that sets flags based on compiler name string. This update adds yet another set of cases for `cc` and `ftn` compiler names.

Based on notes from Weiqun Zhang @ lbl (I don't have GitHub handle).