### PR TITLE
CMake: (fix) MPI parallel HDF5 1.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ if (FORTRAN_INTERFACE)
 endif ()
 find_package(HDF5 REQUIRED COMPONENTS ${COMPONENTS})
 
+# Find MPI depending on if HDF5 needs MPI.
+if (HDF5_IS_PARALLEL)
+  find_package(MPI REQUIRED COMPONENTS C)
+endif()
+
 # Find ZFP, relies on ZFP_DIR or ZFP_ROOT being set in environment.
 find_package(ZFP REQUIRED CONFIG)
 


### PR DESCRIPTION
- The other day the HDF group has release HDF5 1.14.0. If the MPI parallel version of HDF5 1.14.0 is built using CMake then target MPI::MPI_C is required when using the target ${HDF5_LIBRARIES} in a CMake project like H5Z-ZFP. I have implemented finding the required MPI target in the case if HDF5 is parallel.