### PR TITLE
Bugfix/hdf5 1.14.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Install Dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
+        sudo apt-get update
         sudo apt-get install -qq libhdf5-dev
         sudo apt-get install -qq hdf5-tools
         echo  "HDF5_HOME=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial,/usr/bin" >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif ()
 find_package(HDF5 REQUIRED COMPONENTS ${COMPONENTS})
 
 # Find MPI depending on if HDF5 needs MPI.
-if (HDF5_IS_PARALLEL)
+if (HDF5_IS_PARALLEL AND ("${HDF5_VERSION}" VERSION_EQUAL "1.14.0"))
   find_package(MPI REQUIRED COMPONENTS C)
 endif()
 


### PR DESCRIPTION
CMake: (fix) parallel HDF5 1.14.0 and MPI
- The other day, the HDF group fixed a small mistake in their
  generation of the HDF5 CMake configuration file which solves
  the missing target MPI::MPI_C. This fixed will be part
  of future versions of HDF5 (1.8, 1.10, 1.12 and 1.14). As a
  result we only need to call find_package(MPI) for HDF5
  1.14.0 version.

Actions: (fix) apt-get update
- Call apt-get update to ensure we get the latest version
  of the latest packages.