### PR TITLE
fix reading of byte-swapped input files (#95)

### DIFF
--- a/src/H5Zzfp.c
+++ b/src/H5Zzfp.c
@@ -461,11 +461,6 @@ get_zfp_info_from_cd_values(size_t cd_nelmts, unsigned int const *cd_values,
 
     /* Do a read of *just* magic to detect possible codec version mismatch */
     if (0 == (Z zfp_read_header(zstr, zfld, ZFP_HEADER_MAGIC)))
-        H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0, "ZFP codec version mismatch");
-    Z zfp_stream_rewind(zstr);
-
-    /* Now, read ZFP *full* header */
-    if (0 == (Z zfp_read_header(zstr, zfld, ZFP_HEADER_FULL)))
     {
         herr_t conv;
 
@@ -479,9 +474,14 @@ get_zfp_info_from_cd_values(size_t cd_nelmts, unsigned int const *cd_values,
             H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_BADVALUE, 0, "header endian-swap failed");
 
         Z zfp_stream_rewind(zstr);
-        if (0 == (Z zfp_read_header(zstr, zfld, ZFP_HEADER_FULL)))
-            H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_CANTGET, 0, "reading header failed");
+        if (0 == (Z zfp_read_header(zstr, zfld, ZFP_HEADER_MAGIC)))
+            H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_CANTGET, 0, "ZFP codec version mismatch");
     }
+    Z zfp_stream_rewind(zstr);
+
+    /* Now, read ZFP *full* header */
+    if (0 == (Z zfp_read_header(zstr, zfld, ZFP_HEADER_FULL)))
+        H5Z_ZFP_PUSH_AND_GOTO(H5E_PLINE, H5E_CANTGET, 0, "reading header failed");
 
     /* Get ZFP stream mode and field meta */
     *zfp_mode = Z zfp_stream_mode(zstr);


### PR DESCRIPTION
When reading a byte-swapped file, the input is grouped to 4-byte words and each of them is swapped individually. When we try to read such a file, we first validate its header using zfp_read_header with the ZFP_HEADER_MAGIC flag. This flag causes it to only validate the first word to be "zfp\x05". If it is not exactly that, it gives up. Unfortunately, this magic word can already be swapped. The actual byte swapping code would only be tried once the full header would fail to read, so automatic byte swapping never worked.

Instead, when encountering a header with bad magic, try swapping it already and only try reading the full header once the magic (normal or swapped) has been read successfully.

Thanks to Mark C. Miller, Peter Lindstrom and Enrico Zini for doing most of the debugging to get here.