### PR TITLE
Fix h5repack test

### DIFF
--- a/config.make
+++ b/config.make
@@ -8,6 +8,22 @@ ifeq ($(ZFP_HOME),)
     $(warning WARNING: ZFP_HOME not specified)
 endif
 
+# disallow relative paths in HOME variables
+HOME_WORDS := $(subst /, ,$(HDF5_HOME))
+FIRST_WORD := $(firstword $(HOME_WORDS))
+ifeq ($(FIRST_WORD),.)
+    $(error Please use absolute path for HDF5_HOME)
+else ifeq ($(FIRST_WORD),..)
+    $(error Please use absolute path for HDF5_HOME)
+endif
+HOME_WORDS := $(subst /, ,$(ZFP_HOME))
+FIRST_WORD := $(firstword $(HOME_WORDS))
+ifeq ($(FIRST_WORD),.)
+    $(error Please use absolute path for ZFP_HOME)
+else ifeq ($(FIRST_WORD),..)
+    $(error Please use absolute path for ZFP_HOME)
+endif
+
 # Construct version variable depending on what dir we're in
 PWD_BASE = $(shell basename $$(pwd))
 ifeq ($(PWD_BASE),src)

--- a/test/Makefile
+++ b/test/Makefile
@@ -346,17 +346,22 @@ test-reversible: plugin test_write_plugin
 # Uses h5repack to test ZFP filter on float and int datasets in
 # 1,2,3 and 4 dimensions. Note: need to specify raw cd_values on
 # command-line to h5repack. We can get these from an invokation
-# of test_write which prints them in the header output. The values
-# here are for accuracy mode and tolerance of 0.001.
+# of print_h5repack_farg. The values here are for accuracy mode
+# and tolerance of 0.001.
 # 
 # A bug-fix patch to h5repack_parse.c is required for this test on
 # older HDF5 versions (like <= 1.8.10).
 #
-test-h5repack: plugin mesh.h5 patch
+# Note use h5repack `-n` option to ensure machine native format
+# used when copying datasets to output file. Also, use filter flag
+# of 0 in h5repack's UD argument to make the filter mandatory.
+#
+test-h5repack: plugin mesh.h5 patch print_h5repack_farg
 	@echo " "; \
 	pad=$$(printf '%*s' "$(padlimit)"); \
 	pad=$${pad// /.}; \
-	x="h5repack -f UD=32013,0,4,3,0,3539053052,1062232653"; \
+        rparg=$$(./print_h5repack_farg zfpmode=3 acc=0.001 | grep '^. *-f'); \
+	x="h5repack -n $$rparg"; \
         printf "$$x"; \
 	printf ' %*.*s' 0 $$(($(padlength) - $${#x} )) "$$pad"; \
 	env LD_LIBRARY_PATH=$(HDF5_LIB):$(LD_LIBRARY_PATH) HDF5_PLUGIN_PATH=$(H5Z_ZFP_PLUGIN) $(HDF5_BIN)/$$x \


### PR DESCRIPTION
This fixes h5repack test for any endian machine.

Resolves #100

* Adds `-n` (use native types) to `h5repack`
* Uses output from `print_h5repack_farg` to generate argument to `h5repack` test
* Add logic to disallow and print error message if using relative paths for `ZFP_HOME` or `HDF5_HOME` in vanilla gnu make builds