### PR TITLE
Fix leak and consistify generic API with ZFP C API

### DIFF
--- a/config.make
+++ b/config.make
@@ -50,7 +50,7 @@ ifeq ($(ZFP_LIB_VERSION),)
     ZFP_LIB_VERSION := $(shell grep '^\#define ZFP_VERSION_[MRPT]' $(ZFP_HOME)/inc/zfp.h 2>/dev/null | tr ' ' '\n' | grep '[0-9]' | tr -d '\n' 2>/dev/null)
 endif
 ifeq ($(ZFP_LIB_VERSION),)
-    $(warning WARNING: ZFP lib version not detected by make -- some tests may run)
+    $(warning WARNING: ZFP lib version not detected by make -- some tests may be skipped)
 endif
 
 # Detect system type
@@ -161,7 +161,7 @@ else ifneq ($(wildcard $(ZFP_HOME)/inc),)
 ZFP_INC = $(ZFP_HOME)/inc
 endif
 ifeq ($(wildcard $(ZFP_INC)/zfp.h),) # no header file
-$(error "zfp.h not found")
+$(warning "zfp.h not found")
 endif
 
 ifeq ($(wildcard $(ZFP_HOME)/lib),)

--- a/src/H5Zzfp_plugin.h
+++ b/src/H5Zzfp_plugin.h
@@ -25,15 +25,14 @@ CD[0]=CD[1]=CD[2]=CD[3]=0;                       \
 CD[0]=H5Z_ZFP_MODE_RATE; *p=R; N=4;}} while(0)
 
 #define H5Pget_zfp_rate_cdata(N, CD) \
-((double)(((N>=4)&&(CD[0]==H5Z_ZFP_MODE_RATE))?*((double *) &CD[2]):-1))
+((double)(((N>=4)&&(CD[0]==H5Z_ZFP_MODE_RATE))?*((double *) &CD[2]):0))
 
 #define H5Pset_zfp_precision_cdata(P, N, CD)  \
-do { if (N>=3) {CD[0]=CD[1]=CD[2];            \
-CD[0]=H5Z_ZFP_MODE_PRECISION;                 \
-CD[2]=P; N=3;}} while(0)
+do { if (N>=3) {CD[0]=H5Z_ZFP_MODE_PRECISION; \
+CD[1]=0; CD[2]=P; N=3;}} while(0)
 
 #define H5Pget_zfp_precision_cdata(N, CD) \
-((double)(((N>=3)&&(CD[0]==H5Z_ZFP_MODE_ACCURACY))?CD[2]:-1))
+((double)(((N>=3)&&(CD[0]==H5Z_ZFP_MODE_PRECISION))?CD[2]:0))
 
 #define H5Pset_zfp_accuracy_cdata(A, N, CD)      \
 do { if (N>=4) {double *p = (double *) &CD[2];   \
@@ -41,7 +40,7 @@ CD[0]=CD[1]=CD[2]=CD[3]=0;                       \
 CD[0]=H5Z_ZFP_MODE_ACCURACY; *p=A; N=4;}} while(0)
 
 #define H5Pget_zfp_accuracy_cdata(N, CD) \
-((double)(((N>=4)&&(CD[0]==H5Z_ZFP_MODE_ACCURACY))?*((double *) &CD[2]):-1))
+((double)(((N>=4)&&(CD[0]==H5Z_ZFP_MODE_ACCURACY))?*((double *) &CD[2]):0))
 
 #define H5Pset_zfp_expert_cdata(MiB, MaB, MaP, MiE, N, CD) \
 do { if (N>=6) { CD[0]=CD[1]=CD[2]=CD[3]=CD[4]=CD[5]=0;    \
@@ -66,6 +65,6 @@ do { if (N>=1) {                                 \
 CD[0]=H5Z_ZFP_MODE_REVERSIBLE; N=1;}} while(0)
 
 #define H5Pget_zfp_reversible_cdata(N, CD) \
-((int)(((N>=1)&&(CD[0]==H5Z_ZFP_MODE_REVERSIBLE))?1:-1))
+((int)(((N>=1)&&(CD[0]==H5Z_ZFP_MODE_REVERSIBLE))?1:0))
 
 #endif

--- a/src/H5Zzfp_props.c
+++ b/src/H5Zzfp_props.c
@@ -5,6 +5,7 @@
 
 #include <stdarg.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define H5Z_ZFP_PUSH_AND_GOTO(MAJ, MIN, RET, MSG)     \
 do                                                    \
@@ -18,14 +19,14 @@ do                                                    \
 static herr_t H5Pset_zfp(hid_t plist, int mode, ...)
 {
     static char const *_funcname_ = "H5Pset_zfp";
-    static size_t ctrls_sz = sizeof(h5z_zfp_controls_t);
+    static size_t const ctrls_sz = sizeof(h5z_zfp_controls_t);
     unsigned int flags;
     size_t cd_nelmts = 0;
     unsigned int cd_values[1];
     h5z_zfp_controls_t *ctrls_p = 0;
     int i;
     va_list ap;
-    herr_t retval;
+    herr_t retval = 0;
 
     if (0 >= H5Pisa_class(plist, H5P_DATASET_CREATE))
         H5Z_ZFP_PUSH_AND_GOTO(H5E_ARGS, H5E_BADTYPE, -1, "not a dataset creation property list class");
@@ -100,6 +101,9 @@ static herr_t H5Pset_zfp(hid_t plist, int mode, ...)
     {
         retval = H5Pset(plist, "zfp_controls", ctrls_p);
     }
+
+    /* HDF5 copies the memory we gave it */
+    free(ctrls_p);
 
     return retval;
 

--- a/test/test_write.c
+++ b/test/test_write.c
@@ -336,7 +336,7 @@ static hid_t setup_filter(int n, hsize_t *chunk, int zfpmode,
         cd_nelmts = 0; /* causes default behavior of ZFP library */
 
     /* print cd-values array used for filter */
-    printf("%d cd_values= ", (int) cd_nelmts);
+    printf("\n%d cd_values=", (int) cd_nelmts);
     for (int i = 0; i < (int) cd_nelmts; i++)
         printf("%u,", cd_values[i]);
     printf("\n");


### PR DESCRIPTION
- This update fixes a leak of property data when the filter is used as a library (instead of a plugin)
- This also adjusts the generic interface (CPP macros) to set a value of 0 instead of -1 when getting rate, precision or accuracy from a `cd_vals` array to make it consistent with ZFP C API.
- Also fixed a bug in generic interface in `5Pget_zfp_precision_cdata` which set incorrect mode
- Also fixed a UMR bug in generic interface when printing `cd_vals`...an *unused* value was not set and so printing the array of `cd_vals` resulted in printing uninitialized memory. Maybe this was happening on Windows...but it would only show up during tests of `test_write_plugin` as that is only executable using generic interface.
- Made gnumake warn instead of error if no `zfp.h` found so that `make help` always prints someting useful