### PR TITLE
Handle static-only HDF5 library

### DIFF
--- a/config.make
+++ b/config.make
@@ -218,6 +218,15 @@ ifeq ($(shell grep H5Dwrite_chunk $(HDF5_INC)/*.h),)
     HDF5_HAS_WRITE_CHUNK = 0
 endif
 
+HDF5_IS_STATIC_ONLY = 1
+ifneq ($(wildcard $(HDF5_LIB)/libhdf5.so),)
+  HDF5_IS_STATIC_ONLY = 0
+else ifneq ($(wildcard $(HDF5_LIB)/libhdf5.dylib),)
+  HDF5_IS_STATIC_ONLY = 0
+else ifneq ($(wildcard $(HDF5_LIB)/libhdf5.dll),)
+  HDF5_IS_STATIC_ONLY = 0
+endif
+
 ifeq ($(PREFIX),)
     PREFIX := $(shell pwd)/install
 endif

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,8 @@ Compiling ZFP_
 Compiling HDF5_
 ^^^^^^^^^^^^^^^
 
+* If you want to test the plugin as a dynamically loaded plugin, the HDF5_ library must NOT be configured with ``--disable-shared``.
+
 * If you want to be able to run the fortran tests for this filter, HDF5_ must be configured with *both* the ``--enable-fortran`` and ``--enable-fortran2003`` configuration switches.
   Otherwise, any vanilla installation of HDF5_ is acceptable.
   

--- a/test/Makefile
+++ b/test/Makefile
@@ -725,11 +725,15 @@ ifneq ($(ZFP_HAS_REVERSIBLE),)
     LIB_CHECK += test-lib-reversible
 endif
 
-PLUGIN_CHECK = test-rate test-accuracy test-precision test-h5repack
-ifneq ($(ZFP_HAS_REVERSIBLE),)
-    PLUGIN_CHECK += test-reversible
+# Only do plugin tests if HDF5 is built for shared libs
+PLUGIN_CHECK =
+ifneq ($(HDF5_IS_STATIC_ONLY),1)
+    PLUGIN_CHECK = test-rate test-accuracy test-precision test-h5repack
+    ifneq ($(ZFP_HAS_REVERSIBLE),)
+        PLUGIN_CHECK += test-reversible
+    endif
+    PLUGIN_CHECK += test-endian test-endian1
 endif
-PLUGIN_CHECK += test-endian test-endian1
 
 CHECK = $(LIB_CHECK) $(PLUGIN_CHECK)
 ifneq ($(FC),)


### PR DESCRIPTION
Resolves #137 

* Added logic to `config.make` to detect if `libhdf5.{so,dylib,dll}` is present in `HDF5_LIB` directory. If it is **NOT**, plugin tests are disabled.
* Added a line to documentation about installing HDF5 to not use `--disable-shared` configuration.